### PR TITLE
Properly initialize esp_ble_scan_params_t to enable scan duplicate filtering

### DIFF
--- a/main/bluetooth.c
+++ b/main/bluetooth.c
@@ -15,7 +15,8 @@ static esp_ble_scan_params_t ruuvi_gw_bluetooth_scan_params = {
   .own_addr_type = BLE_ADDR_TYPE_PUBLIC,
   .scan_filter_policy = BLE_SCAN_FILTER_ALLOW_ALL,
   .scan_interval = 0x50,
-  .scan_window = 0x30
+  .scan_window = 0x30,
+  .scan_duplicate = BLE_SCAN_DUPLICATE_ENABLE
 };
 
 static void ruuvi_gw_bluetooth_gap_cb(esp_gap_ble_cb_event_t event,


### PR DESCRIPTION
Right now if bluetooth scan duration is increased we get a lot of duplicate messages from ruuvitags because they send measurement data around once per second and we publish all of them to mqtt. Increasing the scan duration is good for far away ruuvitags with bad signal.

For some time I filtered out duplicates in application code but then I noticed that esp-idf has a scan duplicate feature for quite some time and we broke it.

esp_ble_scan_params_t has a new element scan_duplicate which allows to filter bluetooth devices per address. This scan duplicate filter is enabled per default in recent esp-idf but since we are using our own esp_ble_scan_prams_t struct and we missed setting scan_duplicate this was disabled per default.

Some parameters like number of devices in the cache, detecting duplicates per address or advertising data can also be set in menuconfig. Defaults look sane for ruuvi-gw usecase so I did not touch them.

https://github.com/espressif/esp-idf/blob/454aeb3a48/components/bt/host/bluedroid/api/include/api/esp_gap_ble_api.h#L415