### PR TITLE
Fix negative temperature

### DIFF
--- a/main/bluetooth.c
+++ b/main/bluetooth.c
@@ -63,6 +63,10 @@ static void ruuvi_gw_bluetooth_gap_cb(esp_gap_ble_cb_event_t event,
                   res->scan_rst.bda[5]);
                measurement.temperature = ((res->scan_rst.ble_adv[8] << 8) |
                 res->scan_rst.ble_adv[9]) * 0.005;
+
+               if(measurement.temperature > 163.835)
+                measurement.temperature -= 327.67;
+
                measurement.humidity = ((res->scan_rst.ble_adv[10] << 8) |
                 res->scan_rst.ble_adv[11]) * 0.0025;
                measurement.pressure = (((res->scan_rst.ble_adv[12] << 8) |


### PR DESCRIPTION
Right now negative temperature of -1°C is reported way too high as 326.7°C.

According to the ruuvitag RAWv2 documentation the supported values for temperature are -163.835 °C to +163.835 °C in 0.005 °C increments and 327.67 is the full range.

This was cross checked with the values reported by the Ruuvitag App and is working fine for me for some months now.