### PR TITLE
Extend and fix parsing code for RAWv2 blobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,32 @@ by a more recognizable device name by adding a line to `ethers` file.
 
 The log should look like this:
 
-    I (6102) ruuvi-gw-bluetooth: Device Address: C0:09:D8:69:A8:01
-    I (6102) ruuvi-gw-bluetooth: Device Name:    kitchen
-    I (6112) ruuvi-gw-bluetooth: Temperature:    22.06 C
-    I (6112) ruuvi-gw-bluetooth: Humidity:       26.26 %
-    I (9412) ruuvi-gw-bluetooth: 
-    I (9412) ruuvi-gw-bluetooth: Device Address: EE:57:0F:54:B7:94
-    I (9412) ruuvi-gw-bluetooth: Device Name:    bedroom
-    I (9412) ruuvi-gw-bluetooth: Temperature:    22.26 C
-    I (9422) ruuvi-gw-bluetooth: Humidity:       24.96 %
+    I (7317) ruuvi-gw-mqtt: Device Address: D4:2C:7F:62:4E:63
+    I (7317) ruuvi-gw-mqtt: Device Name:    kitchen
+    I (7327) ruuvi-gw-mqtt: Temperature:    16.71 C
+    I (7327) ruuvi-gw-mqtt: Humidity:       44.80 %
+    I (7337) ruuvi-gw-mqtt: Pressure:       973 hPa
+    I (7337) ruuvi-gw-mqtt: Acceleration X: -0.016 G
+    I (7347) ruuvi-gw-mqtt: Acceleration Y: -0.028 G
+    I (7347) ruuvi-gw-mqtt: Acceleration Z: 1.028 G
+    I (7357) ruuvi-gw-mqtt: Battery:        2.967 V
+    I (7357) ruuvi-gw-mqtt: TX Power:       4 dBm
+    I (7367) ruuvi-gw-mqtt: Moves:          70
+    I (7367) ruuvi-gw-mqtt: Sequence:       49685
+    I (7367) ruuvi-gw-mqtt:
+    I (9427) ruuvi-gw-mqtt: Device Address: FE:5F:48:FB:C6:89
+    I (9427) ruuvi-gw-mqtt: Device Name:    bedroom
+    I (9427) ruuvi-gw-mqtt: Temperature:    20.42 C
+    I (9437) ruuvi-gw-mqtt: Humidity:       45.36 %
+    I (9437) ruuvi-gw-mqtt: Pressure:       973 hPa
+    I (9447) ruuvi-gw-mqtt: Acceleration X: 0.048 G
+    I (9447) ruuvi-gw-mqtt: Acceleration Y: 0.012 G
+    I (9457) ruuvi-gw-mqtt: Acceleration Z: 0.968 G
+    I (9457) ruuvi-gw-mqtt: Battery:        2.865 V
+    I (9467) ruuvi-gw-mqtt: TX Power:       4 dBm
+    I (9467) ruuvi-gw-mqtt: Moves:          211
+    I (9477) ruuvi-gw-mqtt: Sequence:       56059
+
 
 ## License
 

--- a/main/bluetooth.c
+++ b/main/bluetooth.c
@@ -61,13 +61,36 @@ static void ruuvi_gw_bluetooth_gap_cb(esp_gap_ble_cb_event_t event,
                   res->scan_rst.bda[3],
                   res->scan_rst.bda[4],
                   res->scan_rst.bda[5]);
-               measurement.temperature = ((res->scan_rst.ble_adv[8] << 8) |
+              measurement.temperature = ((res->scan_rst.ble_adv[8] << 8) |
                 res->scan_rst.ble_adv[9]) * 0.005;
-               measurement.humidity = ((res->scan_rst.ble_adv[10] << 8) |
+
+              if(measurement.temperature > 163.836)
+                measurement.temperature -= 327.68;
+
+              measurement.humidity = ((res->scan_rst.ble_adv[10] << 8) |
                 res->scan_rst.ble_adv[11]) * 0.0025;
-               measurement.pressure = (((res->scan_rst.ble_adv[12] << 8) |
-                res->scan_rst.ble_adv[13]) + 50000) / 100;
-               measurement.moves = res->scan_rst.ble_adv[22];
+              measurement.pressure = (((res->scan_rst.ble_adv[12] << 8) |
+                res->scan_rst.ble_adv[13]) + 50000);
+              measurement.acceleration_x = ((res->scan_rst.ble_adv[14] << 8) |
+                res->scan_rst.ble_adv[15]) / 1000.0;
+              measurement.acceleration_y = ((res->scan_rst.ble_adv[16] << 8) |
+                res->scan_rst.ble_adv[17]) / 1000.0;
+              measurement.acceleration_z = ((res->scan_rst.ble_adv[18] << 8) |
+                res->scan_rst.ble_adv[19]) / 1000.0;
+
+              if(measurement.acceleration_x > 32.767)
+                measurement.acceleration_x -= 65.536;
+              if(measurement.acceleration_y > 32.767)
+                measurement.acceleration_y -= 65.536;
+              if(measurement.acceleration_z > 32.767)
+                measurement.acceleration_z -= 65.536;
+
+              measurement.battery = (((res->scan_rst.ble_adv[20] << 3) |
+                (res->scan_rst.ble_adv[21] >> 5))  + 1600) / 1000.0;
+              measurement.txpower = ((res->scan_rst.ble_adv[21] & 0x1f) * 2) - 40;
+              measurement.moves = res->scan_rst.ble_adv[22];
+              measurement.sequence = ((res->scan_rst.ble_adv[23] << 8) |
+                res->scan_rst.ble_adv[24]);
 
               ruuvi_gw_mqtt_add_measurement(measurement);
 

--- a/main/measurement_data.h
+++ b/main/measurement_data.h
@@ -6,8 +6,14 @@ typedef struct measurement_data_t {
   char bda[18];
   float temperature;
   float humidity;
-  int pressure;
-  int moves;
+  unsigned int pressure;
+  float acceleration_x;
+  float acceleration_y;
+  float acceleration_z;
+  float battery;
+  int txpower;
+  unsigned int moves;
+  unsigned int sequence;
 } measurement_data_t;
 
 #endif

--- a/main/mqtt.c
+++ b/main/mqtt.c
@@ -56,11 +56,23 @@ static void mqtt_event_handler(void *handler_args, esp_event_base_t base,
         ESP_LOGI(TAG, "Device Name:    %s", measurement->name);
         ESP_LOGI(TAG, "Temperature:    %.2f C", measurement->temperature);
         ESP_LOGI(TAG, "Humidity:       %.2f %%", measurement->humidity);
-        ESP_LOGI(TAG, "Pressure:       %d hPa", measurement->pressure);
+        ESP_LOGI(TAG, "Pressure:       %d hPa", measurement->pressure/100);
+        ESP_LOGI(TAG, "Acceleration X: %.3f G", measurement->acceleration_x);
+        ESP_LOGI(TAG, "Acceleration Y: %.3f G", measurement->acceleration_y);
+        ESP_LOGI(TAG, "Acceleration Z: %.3f G", measurement->acceleration_z);
+        ESP_LOGI(TAG, "Battery:        %.3f V", measurement->battery);
+        ESP_LOGI(TAG, "TX Power:       %d dBm", measurement->txpower);
         ESP_LOGI(TAG, "Moves:          %d", measurement->moves);
+        ESP_LOGI(TAG, "Sequence:       %d", measurement->sequence);
     
         char topic[100];
-        char data[10];
+        char data[20];
+
+        sprintf(topic, "%s/%s/mac", CONFIG_RUUVI_GW_MQTT_TOPIC,
+            measurement->name);
+        sprintf(data, "%s", measurement->bda);
+        esp_mqtt_client_publish(client, topic, data, 0, CONFIG_RUUVI_GW_MQTT_QOS,
+            CONFIG_RUUVI_GW_MQTT_RETAIN);
 
         sprintf(topic, "%s/%s/temperature", CONFIG_RUUVI_GW_MQTT_TOPIC, 
             measurement->name);
@@ -76,13 +88,49 @@ static void mqtt_event_handler(void *handler_args, esp_event_base_t base,
 
         sprintf(topic, "%s/%s/pressure", CONFIG_RUUVI_GW_MQTT_TOPIC,
             measurement->name);
-        sprintf(data, "%d", measurement->pressure);
+        sprintf(data, "%d", measurement->pressure/100);
+        esp_mqtt_client_publish(client, topic, data, 0, CONFIG_RUUVI_GW_MQTT_QOS,
+            CONFIG_RUUVI_GW_MQTT_RETAIN);
+
+        sprintf(topic, "%s/%s/acceleration_x", CONFIG_RUUVI_GW_MQTT_TOPIC,
+            measurement->name);
+        sprintf(data, "%.3f", measurement->acceleration_x);
+        esp_mqtt_client_publish(client, topic, data, 0, CONFIG_RUUVI_GW_MQTT_QOS,
+            CONFIG_RUUVI_GW_MQTT_RETAIN);
+
+        sprintf(topic, "%s/%s/acceleration_y", CONFIG_RUUVI_GW_MQTT_TOPIC,
+            measurement->name);
+        sprintf(data, "%.3f", measurement->acceleration_y);
+        esp_mqtt_client_publish(client, topic, data, 0, CONFIG_RUUVI_GW_MQTT_QOS,
+            CONFIG_RUUVI_GW_MQTT_RETAIN);
+
+        sprintf(topic, "%s/%s/acceleration_z", CONFIG_RUUVI_GW_MQTT_TOPIC,
+            measurement->name);
+        sprintf(data, "%.3f", measurement->acceleration_z);
+        esp_mqtt_client_publish(client, topic, data, 0, CONFIG_RUUVI_GW_MQTT_QOS,
+            CONFIG_RUUVI_GW_MQTT_RETAIN);
+
+        sprintf(topic, "%s/%s/battery", CONFIG_RUUVI_GW_MQTT_TOPIC,
+            measurement->name);
+        sprintf(data, "%.3f", measurement->battery);
+        esp_mqtt_client_publish(client, topic, data, 0, CONFIG_RUUVI_GW_MQTT_QOS,
+            CONFIG_RUUVI_GW_MQTT_RETAIN);
+
+        sprintf(topic, "%s/%s/txpower", CONFIG_RUUVI_GW_MQTT_TOPIC,
+            measurement->name);
+        sprintf(data, "%.d", measurement->txpower);
         esp_mqtt_client_publish(client, topic, data, 0, CONFIG_RUUVI_GW_MQTT_QOS,
             CONFIG_RUUVI_GW_MQTT_RETAIN);
 
         sprintf(topic, "%s/%s/moves", CONFIG_RUUVI_GW_MQTT_TOPIC,
             measurement->name);
         sprintf(data, "%d", measurement->moves);
+        esp_mqtt_client_publish(client, topic, data, 0, CONFIG_RUUVI_GW_MQTT_QOS,
+            CONFIG_RUUVI_GW_MQTT_RETAIN);
+
+        sprintf(topic, "%s/%s/sequence", CONFIG_RUUVI_GW_MQTT_TOPIC,
+            measurement->name);
+        sprintf(data, "%d", measurement->sequence);
         esp_mqtt_client_publish(client, topic, data, 0, CONFIG_RUUVI_GW_MQTT_QOS,
             CONFIG_RUUVI_GW_MQTT_RETAIN);
       }


### PR DESCRIPTION
Extend parsing code for RAWv2 blobs and also send new values via mqtt.

This also fixes negative temperature to be reported as ~327°C.

Tested with the documented test vectors from the ruuvi documentation with
the following code snippet.
https://docs.ruuvi.com/communication/bluetooth-advertisements/data-format-5-rawv2

```
#include <stdio.h>
#include <string.h>

typedef struct measurement_data_t {
  float temperature;
  float humidity;
  unsigned int pressure;
  float acceleration_x;
  float acceleration_y;
  float acceleration_z;
  float battery;
  int txpower;
  unsigned int moves;
  unsigned int sequence;
  unsigned char mac[6];
} measurement_data_t;

int main ()
{
  // text vectors from official ruuvi documentation
  // https://docs.ruuvi.com/communication/bluetooth-advertisements/data-format-5-rawv2

  // valid values
  unsigned char ble_adv[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05, 0x12, 0xFC, 0x53, 0x94, 0xC3, 0x7C, 0x00, 0x04, 0xFF, 0xFC, 0x04, 0x0C, 0xAC, 0x36, 0x42, 0x00, 0xCD, 0xCB, 0xB8, 0x33, 0x4C, 0x88, 0x4F };

  // maximum values
  //unsigned char ble_adv[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05, 0x7F, 0xFF, 0xFF, 0xFE, 0xFF, 0xFE, 0x7F, 0xFF, 0x7F, 0xFF, 0x7F, 0xFF, 0xFF, 0xDE, 0xFE, 0xFF, 0xFE, 0xCB, 0xB8, 0x33, 0x4C, 0x88, 0x4F };

  // minimum values
  //unsigned char ble_adv[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05, 0x80, 0x01, 0x00, 0x00, 0x00, 0x00, 0x80, 0x01, 0x80, 0x01, 0x80, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0xCB, 0xB8, 0x33, 0x4C, 0x88, 0x4F };

  // invalid values
  //unsigned char ble_adv[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05, 0x80, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x80, 0x00, 0x80, 0x00, 0x80, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };

  measurement_data_t measurement = { };

  measurement.temperature = ((ble_adv[8] << 8) | ble_adv[9]) * 0.005;
  if(measurement.temperature > 163.836)
    measurement.temperature -= 327.68;

  measurement.humidity = ((ble_adv[10] << 8) | ble_adv[11]) * 0.0025;
  measurement.pressure = (((ble_adv[12] << 8) | ble_adv[13]) + 50000);
  measurement.acceleration_x = ((ble_adv[14] << 8) | ble_adv[15]) / 1000.0;
  measurement.acceleration_y = ((ble_adv[16] << 8) | ble_adv[17]) / 1000.0;
  measurement.acceleration_z = ((ble_adv[18] << 8) | ble_adv[19]) / 1000.0;

  if(measurement.acceleration_x > 32.767)
    measurement.acceleration_x -= 65.536;
  if(measurement.acceleration_y > 32.767)
    measurement.acceleration_y -= 65.536;
  if(measurement.acceleration_z > 32.767)
    measurement.acceleration_z -= 65.536;

  measurement.battery = (((ble_adv[20] << 3) | (ble_adv[21] >> 5))  + 1600) / 1000.0;
  measurement.txpower = ((ble_adv[21] & 0x1f) * 2) - 40;
  measurement.moves = ble_adv[22];
  measurement.sequence = ((ble_adv[23] << 8) | ble_adv[24]);
  memcpy(measurement.mac, ble_adv+25, 6);

  printf("Temperature:    %.3f C\n", measurement.temperature);
  printf("Humidity:       %.4f %%\n", measurement.humidity);
  printf("Pressure:       %d Pa\n", measurement.pressure);
  printf("Acceleration X  %.3f G\n", measurement.acceleration_x);
  printf("Acceleration Y  %.3f G\n", measurement.acceleration_y);
  printf("Acceleration Z  %.3f G\n", measurement.acceleration_z);
  printf("Battery:        %.3f V\n", measurement.battery);
  printf("TX Power:       %d dBm\n", measurement.txpower);
  printf("Moves:          %d\n", measurement.moves);
  printf("Sequence:       %d\n", measurement.sequence);
  printf("MAC:            %x %x %x %x %x %x\n", measurement.mac[0], measurement.mac[1], measurement.mac[2],
    measurement.mac[3], measurement.mac[4], measurement.mac[5]);

  return 0;
}
```